### PR TITLE
Cache strategy

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,7 +40,8 @@ jobs:
 
       - shell: bash -l {0}
         run: |
-          mamba install --file environment.yml
+          mamba install --file requirements.txt
+          pip install extruct
 
       #----------------------------------------------
       # Code quality check

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,8 +40,7 @@ jobs:
 
       - shell: bash -l {0}
         run: |
-          mamba install --file requirements.txt
-          pip install extruct
+          mamba install --file environment.yml
 
       #----------------------------------------------
       # Code quality check

--- a/app.py
+++ b/app.py
@@ -53,6 +53,8 @@ from profiles.bioschemas_shape_gen import validate_any_from_microdata
 import git
 
 app = Flask(__name__)
+
+app.logger.setLevel(logging.DEBUG)
 CORS(app)
 app.config["CORS_HEADERS"] = "Content-Type"
 

--- a/environment.yml
+++ b/environment.yml
@@ -25,5 +25,6 @@ dependencies:
   - coverage==6.2
   - gitpython
   - pip
+  - cachetools==5.0.0
   - pip:
     - extruct==0.13.0

--- a/metrics/util.py
+++ b/metrics/util.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from lxml import html
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
-
+from cachetools import cached, TTLCache
 from flask import Flask
 
 import logging
@@ -22,6 +22,11 @@ import validators
 from requests.auth import HTTPBasicAuth
 
 from flask import current_app
+
+# caching results during 24 hours
+cache_OLS = TTLCache(maxsize=500, ttl=24 * 3600)
+cache_LOV = TTLCache(maxsize=500, ttl=24 * 3600)
+cache_BP = TTLCache(maxsize=500, ttl=24 * 3600)
 
 app = Flask(__name__)
 
@@ -175,6 +180,7 @@ def get_DOI(uri):
     return match.group(0)
 
 
+@cached(cache_BP)
 def ask_BioPortal(uri, type):
 
     logging.debug(f"Call to the BioPortal REST API for [ {uri} ]")
@@ -209,6 +215,7 @@ def ask_BioPortal(uri, type):
         return False
 
 
+@cached(cache_OLS)
 def ask_OLS(uri):
     """
     Checks that the URI is registered in one of the ontologies indexed in OLS.
@@ -234,6 +241,7 @@ def ask_OLS(uri):
         return False
 
 
+@cached(cache_LOV)
 def ask_LOV(uri):
     """
     Checks that the URI is registered in one of the ontologies indexed in LOV (Linked Open Vocabularies).

--- a/metrics/util.py
+++ b/metrics/util.py
@@ -25,12 +25,14 @@ from requests.auth import HTTPBasicAuth
 
 from flask import current_app
 
+app = Flask(__name__)
+
 # caching results during 24 hours
+app.logger.info("new cache instances")
 cache_OLS = TTLCache(maxsize=5000, ttl=timedelta(hours=24), timer=datetime.now)
 cache_LOV = TTLCache(maxsize=5000, ttl=timedelta(hours=24), timer=datetime.now)
 cache_BP = TTLCache(maxsize=5000, ttl=timedelta(hours=24), timer=datetime.now)
 
-app = Flask(__name__)
 
 # if app.config["ENV"] == "production":
 app.config.from_object("config.Config")
@@ -185,7 +187,7 @@ def get_DOI(uri):
 @cached(cache_BP)
 def ask_BioPortal(uri, type):
 
-    logging.debug(f"Call to the BioPortal REST API for [ {uri} ]")
+    app.logger.debug(f"Call to the BioPortal REST API for [ {uri} ]")
     # print(app.config)
     with app.app_context():
         api_key = current_app.config["BIOPORTAL_APIKEY"]
@@ -212,8 +214,8 @@ def ask_BioPortal(uri, type):
         else:
             return False
     else:
-        logging.error("Cound not contact BioPortal")
-        logging.error(res.text)
+        app.logger.error("Cound not contact BioPortal")
+        app.logger.error(res.text)
         return False
 
 
@@ -224,7 +226,7 @@ def ask_OLS(uri):
     :param uri:
     :return: True if the URI is registered in one of the ontologies indexed in OLS, False otherwise.
     """
-    logging.debug(f"Call to the OLS REST API for [ {uri} ]")
+    app.logger.debug(f"Call to the OLS REST API for [ {uri} ]")
     # uri = requests.compat.quote_plus(uri)
     h = {"Accept": "application/json"}
     p = {"iri": uri}
@@ -232,11 +234,6 @@ def ask_OLS(uri):
     res = requests.get(
         "https://www.ebi.ac.uk/ols/api/properties", headers=h, params=p, verify=True
     )
-    # print(res.status_code)
-    # print(res.headers["content-type"])
-    # print(res.headers)
-    # print(res.encoding)
-    # print(res.json())
     if res.json()["page"]["totalElements"] > 0:
         return True
     else:
@@ -250,7 +247,7 @@ def ask_LOV(uri):
     :param uri:
     :return: True if the URI is registered in one of the ontologies indexed in LOV, False otherwise.
     """
-    logging.debug(
+    app.logger.debug(
         f"SPARQL for [ {uri} ] with enpoint [ https://lov.linkeddata.es/dataset/lov/sparql ]"
     )
 

--- a/metrics/util.py
+++ b/metrics/util.py
@@ -1,3 +1,4 @@
+from time import time
 from SPARQLWrapper import SPARQLWrapper, N3, JSON, RDF, TURTLE, JSONLD
 from rdflib import Graph, ConjunctiveGraph, Namespace
 from rdflib.namespace import RDF
@@ -7,6 +8,7 @@ from pyshacl import validate
 import extruct
 import json
 from pathlib import Path
+from datetime import datetime, timedelta
 
 from lxml import html
 from selenium import webdriver
@@ -24,9 +26,9 @@ from requests.auth import HTTPBasicAuth
 from flask import current_app
 
 # caching results during 24 hours
-cache_OLS = TTLCache(maxsize=500, ttl=24 * 3600)
-cache_LOV = TTLCache(maxsize=500, ttl=24 * 3600)
-cache_BP = TTLCache(maxsize=500, ttl=24 * 3600)
+cache_OLS = TTLCache(maxsize=5000, ttl=timedelta(hours=24), timer=datetime.now)
+cache_LOV = TTLCache(maxsize=5000, ttl=timedelta(hours=24), timer=datetime.now)
+cache_BP = TTLCache(maxsize=5000, ttl=timedelta(hours=24), timer=datetime.now)
 
 app = Flask(__name__)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ flake8==3.7.9
 pytest==6.2.5
 coverage==6.2
 gitpython
+cachetools==5.0.0

--- a/templates/check.html
+++ b/templates/check.html
@@ -577,7 +577,7 @@
     <!-- <div class="section"> -->
     <div class="columns is-centered is-vcentered">
       <div class="column is-half">
-        <progress id="p1" class="progress is-primary is-centered" value="0" max="12"></progress>
+        <progress id="p1" class="progress is-primary is-centered" value="0" max="11"></progress>
 
       </div>
       <div class="column is-narrow">

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,83 @@
+from functools import lru_cache, wraps
+from datetime import datetime, timedelta
+import random
+import time
+import requests
+import unittest
+
+# cache = dict()
+
+# def get_article_from_server(url):
+#     print("Fetching article from server...")
+#     response = requests.get(url)
+#     return response.text
+
+
+# def get_article(url):
+#     print("Getting article...")
+#     if url not in cache:
+#         cache[url] = get_article_from_server(url)
+
+#     return cache[url]
+
+
+# get_article("https://realpython.com/sorting-algorithms-python/")
+# get_article("https://realpython.com/sorting-algorithms-python/")
+
+
+def timeit(method):
+    def timed(*args, **kw):
+        ts = time.time()
+        result = method(*args, **kw)
+        te = time.time()
+        if "log_time" in kw:
+            name = kw.get("log_name", method.__name__.upper())
+            kw["log_time"][name] = int((te - ts) * 1000)
+        else:
+            print("%r  %2.2f ms" % (method.__name__, (te - ts) * 1000))
+        return result
+
+    return timed
+
+
+def timed_lru_cache(seconds: int, maxsize: int = 128):
+    def wrapper_cache(func):
+        func = lru_cache(maxsize=maxsize)(func)
+        func.lifetime = timedelta(seconds=seconds)
+        func.expiration = datetime.utcnow() + func.lifetime
+
+        @wraps(func)
+        def wrapped_func(*args, **kwargs):
+            if datetime.utcnow() >= func.expiration:
+                func.cache_clear()
+                func.expiration = datetime.utcnow() + func.lifetime
+            return func(*args, **kwargs)
+
+        return wrapped_func
+
+    return wrapper_cache
+
+
+# @lru_cache(maxsize=2)
+@timed_lru_cache(8)
+@timeit
+def long_ask():
+    result = random.choice([True, False])
+    time.sleep(3)
+    return result
+
+
+class CacheTestCase(unittest.TestCase):
+    def test_cache(self):
+        print()
+        print(f"Result = {long_ask()}")
+        time.sleep(2)
+        print(f"Result = {long_ask()}")
+        time.sleep(2)
+        print(f"Result = {long_ask()}")
+        time.sleep(2)
+        print(f"Result = {long_ask()}")
+        time.sleep(2)
+        print(f"Result = {long_ask()}")
+        time.sleep(2)
+        print(f"Result = {long_ask()}")

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import datetime
 from rdflib import BNode, ConjunctiveGraph, URIRef
 import metrics.util as util
 from metrics.WebResource import WebResource
@@ -109,17 +110,41 @@ class CommunityVocabTestCase(unittest.TestCase):
         for row in qres:
             table_content["properties"].append({"name": row["prop"], "tag": []})
 
+        start = datetime.now().timestamp()
         class_or_property_found = False
         for c in table_content["classes"]:
             if util.ask_OLS(c["name"]):
                 c["tag"].append("OLS")
                 class_or_property_found = True
+            print(c)
         for p in table_content["properties"]:
             if util.ask_OLS(p["name"]):
                 p["tag"].append("OLS")
                 class_or_property_found = True
+            print(p)
+        end = datetime.now().timestamp()
+        delta = end - start
+        print(f"OLS check done in {delta}")
 
         self.assertTrue(class_or_property_found, True)
+        self.assertGreaterEqual(delta, 2)
+
+        # check that cache is working --> fast answers
+        start = datetime.now().timestamp()
+        for c in table_content["classes"]:
+            if util.ask_OLS(c["name"]):
+                c["tag"].append("OLS")
+                class_or_property_found = True
+            print(c)
+        for p in table_content["properties"]:
+            if util.ask_OLS(p["name"]):
+                p["tag"].append("OLS")
+                class_or_property_found = True
+            print(p)
+        end = datetime.now().timestamp()
+        delta = end - start
+        print(f"OLS check done in {delta}")
+        self.assertLessEqual(delta, 0.1)
 
     def test_LOV(self):
         turtle_edam = self.turtle_edam

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -1,4 +1,3 @@
-from functools import cache
 import unittest
 from datetime import datetime
 from rdflib import BNode, ConjunctiveGraph, URIRef

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -1,3 +1,4 @@
+from functools import cache
 import unittest
 from datetime import datetime
 from rdflib import BNode, ConjunctiveGraph, URIRef
@@ -93,6 +94,8 @@ class CommunityVocabTestCase(unittest.TestCase):
     """
 
     def test_OLS(self):
+        print(util.cache_OLS.values)
+
         turtle_edam = self.turtle_edam
         kg = ConjunctiveGraph()
         kg.parse(data=turtle_edam, format="turtle")
@@ -128,6 +131,7 @@ class CommunityVocabTestCase(unittest.TestCase):
 
         self.assertTrue(class_or_property_found, True)
         self.assertGreaterEqual(delta, 2)
+        print(util.cache_OLS.values)
 
         # check that cache is working --> fast answers
         start = datetime.now().timestamp()
@@ -145,6 +149,7 @@ class CommunityVocabTestCase(unittest.TestCase):
         delta = end - start
         print(f"OLS check done in {delta}")
         self.assertLessEqual(delta, 0.1)
+        print(util.cache_OLS.values)
 
     def test_LOV(self):
         turtle_edam = self.turtle_edam


### PR DESCRIPTION
Use of the the cahetools library https://cachetools.readthedocs.io/en/latest/ to implemengt a cache for SPARQL endpoint results. Configures with a time to live (TTL) of 24h. 