### PR TITLE
Merging small bug fixes to BioSamplesProfile

### DIFF
--- a/metrics/AbstractFAIRMetrics.py
+++ b/metrics/AbstractFAIRMetrics.py
@@ -12,6 +12,7 @@ class AbstractFAIRMetrics(ABC):
 
     COMMON_SPARQL_PREFIX = """
 PREFIX schema: <http://schema.org/>
+PREFIX schema_s: <https://schema.org/>
 PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX doap: <http://usefulinc.com/ns/doap#>

--- a/metrics/F1B_Impl.py
+++ b/metrics/F1B_Impl.py
@@ -150,7 +150,7 @@ Weak : FAIR-Checker verifies that at least one namespace from identifiers.org is
             self.COMMON_SPARQL_PREFIX
             + """ 
 ASK { 
-    VALUES ?p {dct:identifier schema:identifier} . 
+    VALUES ?p {dct:identifier schema:identifier schema_s:identifier} . 
     ?s ?p ?o .
 }
             """

--- a/metrics/R11_Impl.py
+++ b/metrics/R11_Impl.py
@@ -36,6 +36,7 @@ class R11_Impl(AbstractFAIRMetrics):
 
         checked_properties = """
         schema:license
+        schema_s:license
         dct:license
         doap:license
         dbpedia-owl:license

--- a/metrics/R12_Impl.py
+++ b/metrics/R12_Impl.py
@@ -62,6 +62,13 @@ class R12_Impl(AbstractFAIRMetrics):
             schema:provider
             schema:funder
             schema:version
+            schema:creator
+            schema_s:author
+            schema_s:publisher
+            schema_s:provider
+            schema_s:funder
+            schema_s:version
+            schema_s:creator
         """
         query_prov = (
             self.COMMON_SPARQL_PREFIX

--- a/templates/check.html
+++ b/templates/check.html
@@ -80,6 +80,9 @@
       url = $("#url").val();
     }
 
+    // remove any white space inserted before and after the url link input value
+    url = url.trim()
+
     // socket.emit('evaluate_{{f.id}}', {
     socket.emit('evaluate_metric', {
       metric_name: "{{ f.name }}",

--- a/templates/inspect.html
+++ b/templates/inspect.html
@@ -228,7 +228,13 @@
         $("#linkeddata_tab").addClass("is-active");
         $("#section-LinkedData, #section-BioSchemas, #section-Datacite, #section-ENA53").addClass("is-hidden");
         $("#section-LinkedData").removeClass("is-hidden");
-        socket.emit('retrieve_embedded_annot_2', { url: $("#url").val() });
+        
+        let url = $("#url").val()
+        
+        // remove any white space inserted before and after the url link input value
+        url = url.trim()
+
+        socket.emit('retrieve_embedded_annot_2', { url: url });
     });
 
     $("#btn_describe_biotools").click(function () {


### PR DESCRIPTION
# Merging `small-bug-fixes` to `BioSamplesProfile`

This merge request focus on fixing two bugs:

1. Fixed the bug that made resources using https prefix for schema.org not being evaluated fairly
2. Fixed the bug that made the application crash when white spaces were present at the start of or the end of the resource URL

Now, when a resource uses `https` instead of `http` for the `http://schema.org` prefix in its json-ld, the Fair-Checker application recognize still recognize the schema.org prefix. Resources using the `https://schema.org` prefix are no longer penalized by having their license not recognized during the evaluation process, making the Fair-Checker evaluation more resilient.

Also, the URL for the resource can now be copy-pasted with no worry as any white spaces in front or at the end are removed automatically.